### PR TITLE
Add consensus support

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -8,14 +8,13 @@ import (
 )
 
 const (
-	ApiIPsPath = "/api/v1/ips"
+	ApiIPsPath    = "/api/v1/ips"
+	ApiAllIPsPath = "/api/v1/allips"
 )
 
 // For now we don't really have any API, just parsing JSON response with []string data in it.
-
-// GetIPs fetches the IP addresses from the PD Assistant instances.
-func GetIPs(conf cfg.AppConfig, pdaAddress string) ([]string, error) {
-	fullAddress := pdaAddress + ApiIPsPath
+func getIPs(conf cfg.AppConfig, pdaAddress, path string) ([]string, error) {
+	fullAddress := pdaAddress + path
 	resp, err := utils.MakeHTTPRequest(fullAddress, "", "", "", conf.PDAssistantTLSInsecure, conf.HTTPRequestTimeout, conf.BearerToken)
 	// Check if the request was successful
 	if err != nil {
@@ -35,4 +34,14 @@ func GetIPs(conf cfg.AppConfig, pdaAddress string) ([]string, error) {
 	}
 
 	return ips, nil
+}
+
+// GetIPs fetches local IP addresses from the PD Assistant instances.
+func GetLocalIPs(conf cfg.AppConfig, pdaAddress string) ([]string, error) {
+	return getIPs(conf, pdaAddress, ApiIPsPath)
+}
+
+// GetIAllPs fetches all IP addresses from the PD Assistant instances.
+func GetAllIPs(conf cfg.AppConfig, pdaAddress string) ([]string, error) {
+	return getIPs(conf, pdaAddress, ApiAllIPsPath)
 }

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -50,6 +50,7 @@ type AppConfig struct {
 	PDAssistantScheme      string
 	PDAssistantPort        string
 	PDAssistantTLSInsecure bool
+	PDAssistantConsensus   bool
 
 	// HTTPRequestTimeout is the timeout for HTTP requests in seconds.
 	HTTPRequestTimeout int

--- a/internal/cfg/cfg_test.go
+++ b/internal/cfg/cfg_test.go
@@ -25,6 +25,9 @@ func TestLoadCertificateYaml(t *testing.T) {
 	if len(cert.Spec.DNSNames) != 4 {
 		t.Errorf("expected 4 DNS names, got %d", len(cert.Spec.DNSNames))
 	}
+	if len(cert.Spec.IPAddresses) != 5 {
+		t.Errorf("expected 5 IP addresses, got %d", len(cert.Spec.IPAddresses))
+	}
 	if cert.Spec.SecretName != "example-certificate-secret" {
 		t.Errorf("expected secret name 'example-certificate-secret', got '%s'", cert.Spec.SecretName)
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -18,6 +18,7 @@ type AppMetrics struct {
 	// Counters
 	CertUpdateErrors       *prometheus.CounterVec
 	PDAssistantFetchErrors *prometheus.CounterVec
+	ConsensusErrors        *prometheus.CounterVec
 }
 
 func InitMetrics(version string) AppMetrics {
@@ -68,11 +69,21 @@ func InitMetrics(version string) AppMetrics {
 			Name:      "fetch_errors_total",
 			Help:      "Total number of errors fetching data from PD Assistants",
 		},
-		[]string{"pd_assistant"},
+		[]string{"pd_assistant", "type"},
+	)
+
+	am.ConsensusErrors = promauto.With(am.Registry).NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd_assistant",
+			Name:      "consensus_errors_total",
+			Help:      "Total number of errors in consensus check",
+		},
+		[]string{},
 	)
 
 	am.Config.WithLabelValues(version).Set(1)
 	am.CertUpdateErrors.WithLabelValues().Add(0)
+	am.ConsensusErrors.WithLabelValues().Add(0)
 
 	am.Registry.MustRegister()
 	return am

--- a/main.go
+++ b/main.go
@@ -37,16 +37,17 @@ func main() {
 	flag.BoolVar(&showVersion, "version", false, "Show version and exit")
 	// Kubernetes parameters
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file (optional)")
-	flag.IntVar(&config.KubernetesPollInterval, "k8s-poll-interval", 180, "Interval for polling Kubernetes in seconds")
+	flag.IntVar(&config.KubernetesPollInterval, "k8s-poll-interval", 60, "Interval for polling Kubernetes in seconds")
 	// PD assistant parameters
-	flag.IntVar(&config.PDAssistantPollInterval, "pd-assistant-poll-interval", 300, "Interval for polling all pd-assistants in seconds")
+	flag.IntVar(&config.PDAssistantPollInterval, "pd-assistant-poll-interval", 120, "Interval for polling all pd-assistants in seconds")
 	flag.StringVar(&config.PDAssistantHostPrefix, "pd-assistant-host-prefix", "pd-assistant", "Host prefix for PD Assistant instances")
 	flag.StringVar(&config.PDAssistantScheme, "pd-assistant-scheme", "https", "Scheme for PD Assistant instances (http or https)")
 	flag.StringVar(&config.PDAssistantPort, "pd-assistant-port", "443", "Port for PD Assistant instances")
 	flag.BoolVar(&config.PDAssistantTLSInsecure, "pd-assistant-tls-insecure", false, "Skip TLS verification for PD Assistant instances (not recommended)")
 	flag.StringVar(&pdAssistantURLs, "pd-assistant-urls", "", "List of PD Assistant URLs (comma-separated). Overrides --pd-assistant-host-prefix and ignores --pd-address auto-discovery if provided")
+	flag.BoolVar(&config.PDAssistantConsensus, "pd-assistant-consensus", false, "Require consensus from all PD Assistant instances before updating the certificate")
 	// Certificate parameters
-	flag.IntVar(&config.CertUpdateInterval, "cert-update-interval", 300, "Interval for updating PD certificate in seconds")
+	flag.IntVar(&config.CertUpdateInterval, "cert-update-interval", 180, "Interval for updating PD certificate in seconds")
 	flag.StringVar(&certFilePath, "certificate-file", "/app/conf/", "Path to a Certificate YAML file to be used as a template")
 	// PD discovery parameters
 	flag.StringVar(&config.PDDiscoveryConfig.URL, "pd-discovery-url", "", "PD Discovery service URL")
@@ -86,6 +87,11 @@ func main() {
 		glog.V(4).Infof("PD Discovery URL: %s", config.PDDiscoveryConfig.URL)
 	}
 	glog.V(4).Infof("Loaded certificate YAML file %q: name=%s, namespace=%s", certFilePath, config.Certificate.Name, config.Certificate.Namespace)
+	if config.PDAssistantConsensus {
+		glog.V(4).Infof("PD Assistant consensus check is enabled")
+	} else {
+		glog.V(4).Infof("PD Assistant consensus check is disabled")
+	}
 
 	// Let's rock and roll!
 	// Watch CliliumNode IPs and update the state


### PR DESCRIPTION
If enabled, pd-assistant will update certificate only if all pd-assistant instances have the same list of all discovered IPs across clusters.

Also add support for providing common IPs (like 127.0.0.1) via certificate YAML.

## Description

<!--
Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do
extra work to understand the context of this change, which may lead to your
PR taking much longer to review, or result in it not being reviewed at all.
-->

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
